### PR TITLE
Add update lifecycle method

### DIFF
--- a/src/single-spa-svelte.js
+++ b/src/single-spa-svelte.js
@@ -27,7 +27,8 @@ export default function singleSpaSvelte(userOpts) {
   return {
     bootstrap: bootstrap.bind(null, opts, mountedInstances),
     mount: mount.bind(null, opts, mountedInstances),
-    unmount: unmount.bind(null, opts, mountedInstances)
+    unmount: unmount.bind(null, opts, mountedInstances),
+    update: update.bind(null, opts, mountedInstances)
   };
 }
 
@@ -62,6 +63,14 @@ function unmount(opts, mountedInstances) {
     mountedInstances.instance.$destroy
       ? mountedInstances.instance.$destroy()
       : mountedInstances.instance.destroy();
+  });
+}
+
+function update(opts, mountedInstances, props) {
+  return Promise.resolve().then(() => {
+    mountedInstances.instance.$set
+      ? mountedInstances.instance.$set(props)
+      : mountedInstances.instance.set(props);
   });
 }
 

--- a/src/single-spa-svelte.test.js
+++ b/src/single-spa-svelte.test.js
@@ -3,8 +3,16 @@ import singleSpaSvelte from "./single-spa-svelte";
 describe(`single-spa-svelte`, () => {
   it("can bootstrap, mount, and unmount a svelte application", async () => {
     const component = jest.fn();
+    let props = {
+      name: "app1",
+      foo: "bar"
+    };
+    const $set = jest.fn(
+      newProps => (props = Object.assign({}, props, newProps))
+    );
     const $destroy = jest.fn();
     component.mockImplementationOnce(function() {
+      this.$set = $set;
       this.$destroy = $destroy;
     });
     const lifecycles = singleSpaSvelte({
@@ -13,10 +21,6 @@ describe(`single-spa-svelte`, () => {
         thing: "value"
       }
     });
-    const props = {
-      name: "app1",
-      foo: "bar"
-    };
     expect(component).not.toHaveBeenCalled();
     expect($destroy).not.toHaveBeenCalled();
     await lifecycles.bootstrap(props);
@@ -25,7 +29,7 @@ describe(`single-spa-svelte`, () => {
     await lifecycles.mount(props);
     expect(component).toHaveBeenCalled();
     expect($destroy).not.toHaveBeenCalled();
-    const call = component.mock.calls[0][0];
+    let call = component.mock.calls[0][0];
     expect(call.target).toBeDefined();
     expect(call.props).toEqual({
       thing: "value",
@@ -33,6 +37,10 @@ describe(`single-spa-svelte`, () => {
       name: "app1"
     });
     expect($destroy).not.toHaveBeenCalled();
+    await lifecycles.update({ foo: "notbar" });
+    expect($destroy).not.toHaveBeenCalled();
+    expect($set).toHaveBeenCalled();
+    expect(props.foo).toEqual("notbar");
     await lifecycles.unmount();
     expect($destroy).toHaveBeenCalled();
   });


### PR DESCRIPTION
Add update lifecycle method, which uses the svelte component API ([$set](https://svelte.dev/docs#$set)) to update props on the root component when Parcel props are changed.